### PR TITLE
Temporarily restore compatibility with old format

### DIFF
--- a/hypermode.json
+++ b/hypermode.json
@@ -1,134 +1,252 @@
 {
   "$id": "https://manifest.hypermode.com/hypermode.json",
   "$schema": "http://json-schema.org/draft-07/schema",
-  "type": "object",
-  "additionalProperties": false,
-  "properties": {
-    "$schema": {
-      "type": "string",
-      "format": "uri",
-      "description": "The schema that the document should conform to.",
-      "markdownDescription": "The schema that the document should conform to.\n\nReference: https://json-schema.org/"
-    },
-    "models": {
+  "oneOf": [
+    {
+      "$comment": "This is the new format.",
       "type": "object",
-      "propertyNames": {
-        "type": "string",
-        "minLength": 1,
-        "maxLength": 63,
-        "pattern": "^[a-zA-Z0-9]+(?:-[a-zA-Z0-9]+)*$"
-      },
-      "additionalProperties": {
-        "type": "object",
-        "minLength": 1,
-        "maxLength": 2,
-        "required": ["task", "sourceModel", "provider", "host"],
-        "additionalProperties": false,
-        "properties": {
-          "task": {
-            "type": "string",
-            "minLength": 1,
-            "enum": ["classification", "embedding", "generation"],
-            "description": "Training intent of model, such as 'classification' or 'embedding'.",
-            "markdownDescription": "Training intent of model, such as 'classification' or 'embedding'.\n\nReference: https://docs.hypermode.com/define-models"
-          },
-          "sourceModel": {
-            "type": "string",
-            "minLength": 1,
-            "description": "Relative path of model within provider.",
-            "markdownDescription": "Relative path of model within provider.\n\nReference: https://docs.hypermode.com/define-models"
-          },
-          "provider": {
-            "type": "string",
-            "minLength": 1,
-            "description": "Source location of model, such as 'hugging-face' or 'openai'.",
-            "markdownDescription": "Source location of model, such as 'hugging-face' or 'openai'.\n\nReference: https://docs.hypermode.com/define-models"
-          },
-          "host": {
+      "additionalProperties": false,
+      "properties": {
+        "$schema": {
+          "type": "string",
+          "format": "uri",
+          "description": "The schema that the document should conform to.",
+          "markdownDescription": "The schema that the document should conform to.\n\nReference: https://json-schema.org/"
+        },
+        "models": {
+          "type": "object",
+          "propertyNames": {
             "type": "string",
             "minLength": 1,
             "maxLength": 63,
-            "pattern": "^[a-zA-Z0-9]+(?:-[a-zA-Z0-9]+)*$",
-            "description": "Runtime provider of model. Can be dynamically deployed models on Hypermode or a project-defined host.",
-            "markdownDescription": "Runtime provider of model. Can be dynamically deployed models on Hypermode or a project-defined host.\n\nReference: https://docs.hypermode.com/define-models"
+            "pattern": "^[a-zA-Z0-9]+(?:-[a-zA-Z0-9]+)*$"
+          },
+          "additionalProperties": {
+            "type": "object",
+            "minLength": 1,
+            "maxLength": 2,
+            "required": [
+              "task",
+              "sourceModel",
+              "provider",
+              "host"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "task": {
+                "type": "string",
+                "minLength": 1,
+                "enum": [
+                  "classification",
+                  "embedding",
+                  "generation"
+                ],
+                "description": "Training intent of model, such as 'classification' or 'embedding'.",
+                "markdownDescription": "Training intent of model, such as 'classification' or 'embedding'.\n\nReference: https://docs.hypermode.com/define-models"
+              },
+              "sourceModel": {
+                "type": "string",
+                "minLength": 1,
+                "description": "Relative path of model within provider.",
+                "markdownDescription": "Relative path of model within provider.\n\nReference: https://docs.hypermode.com/define-models"
+              },
+              "provider": {
+                "type": "string",
+                "minLength": 1,
+                "description": "Source location of model, such as 'hugging-face' or 'openai'.",
+                "markdownDescription": "Source location of model, such as 'hugging-face' or 'openai'.\n\nReference: https://docs.hypermode.com/define-models"
+              },
+              "host": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 63,
+                "pattern": "^[a-zA-Z0-9]+(?:-[a-zA-Z0-9]+)*$",
+                "description": "Runtime provider of model. Can be dynamically deployed models on Hypermode or a project-defined host.",
+                "markdownDescription": "Runtime provider of model. Can be dynamically deployed models on Hypermode or a project-defined host.\n\nReference: https://docs.hypermode.com/define-models"
+              }
+            }
+          }
+        },
+        "hosts": {
+          "type": "object",
+          "propertyNames": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 63,
+            "pattern": "^[a-zA-Z0-9]+(?:-[a-zA-Z0-9]+)*$"
+          },
+          "additionalProperties": {
+            "type": "object",
+            "properties": {
+              "baseUrl": {
+                "type": "string",
+                "format": "uri",
+                "minLength": 1,
+                "pattern": "^https?://\\S+/$",
+                "description": "Base URL for connections to the host.  Must end with a trailing slash.  If providing the entire URL, use the endpoint field instead.",
+                "markdownDescription": "Base URL for connections to the host.  Must end with a trailing slash.  If providing the entire URL, use the `endpoint` field instead.\n\nReference: https://docs.hypermode.com/define-hosts"
+              },
+              "endpoint": {
+                "type": "string",
+                "format": "uri",
+                "minLength": 1,
+                "pattern": "^https?://\\S+$",
+                "description": "Full URL endpoint for connections to the host.  If providing the base URL, use the baseUrl field instead.",
+                "markdownDescription": "Full URL endpoint for connections to the host.  If providing the base URL, use the `baseUrl` field instead.\n\nReference: https://docs.hypermode.com/define-hosts"
+              },
+              "headers": {
+                "type": "object",
+                "propertyNames": {
+                  "type": "string",
+                  "minLength": 1,
+                  "pattern": "^[\\w!#$%&'*+-.^`|~]+$"
+                },
+                "additionalProperties": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "description": "Headers to include in requests to the host.",
+                "markdownDescription": "Headers to include in requests to the host.\n\nReference: https://docs.hypermode.com/define-hosts"
+              },
+              "queryParameters": {
+                "type": "object",
+                "$comment": "Query parameter keys and values will be encoded when used, so there is no need to validate a pattern in the schema.",
+                "propertyNames": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "additionalProperties": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "description": "Query parameters to include in requests to the host.",
+                "markdownDescription": "Query parameters to include in requests to the host.\n\nReference: https://docs.hypermode.com/define-hosts"
+              }
+            },
+            "$comment": "Either baseUrl or endpoint must be provided, but not both.",
+            "allOf": [
+              {
+                "oneOf": [
+                  {
+                    "required": [
+                      "baseUrl"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "endpoint"
+                    ]
+                  }
+                ],
+                "not": {
+                  "required": [
+                    "baseUrl",
+                    "endpoint"
+                  ]
+                }
+              }
+            ],
+            "additionalProperties": false
           }
         }
       }
     },
-    "hosts": {
+    {
+      "$comment": "This is the old format. We will remove this in the future.",
       "type": "object",
-      "propertyNames": {
-        "type": "string",
-        "minLength": 1,
-        "maxLength": 63,
-        "pattern": "^[a-zA-Z0-9]+(?:-[a-zA-Z0-9]+)*$"
-      },
-      "additionalProperties": {
-        "type": "object",
-        "properties": {
-          "baseUrl": {
-            "type": "string",
-            "format": "uri",
-            "minLength": 1,
-            "pattern": "^https?://\\S+/$",
-            "description": "Base URL for connections to the host.  Must end with a trailing slash.  If providing the entire URL, use the endpoint field instead.",
-            "markdownDescription": "Base URL for connections to the host.  Must end with a trailing slash.  If providing the entire URL, use the `endpoint` field instead.\n\nReference: https://docs.hypermode.com/define-hosts"
-          },
-          "endpoint": {
-            "type": "string",
-            "format": "uri",
-            "minLength": 1,
-            "pattern": "^https?://\\S+$",
-            "description": "Full URL endpoint for connections to the host.  If providing the base URL, use the baseUrl field instead.",
-            "markdownDescription": "Full URL endpoint for connections to the host.  If providing the base URL, use the `baseUrl` field instead.\n\nReference: https://docs.hypermode.com/define-hosts"
-          },
-          "headers": {
-            "type": "object",
-            "propertyNames": {
-              "type": "string",
-              "minLength": 1,
-              "pattern": "^[\\w!#$%&'*+-.^`|~]+$"
-            },
-            "additionalProperties": {
-              "type": "string",
-              "minLength": 1
-            },
-            "description": "Headers to include in requests to the host.",
-            "markdownDescription": "Headers to include in requests to the host.\n\nReference: https://docs.hypermode.com/define-hosts"
-          },
-          "queryParameters": {
-            "type": "object",
-            "$comment": "Query parameter keys and values will be encoded when used, so there is no need to validate a pattern in the schema.",
-            "propertyNames": {
-              "type": "string",
-              "minLength": 1
-            },
-            "additionalProperties": {
-              "type": "string",
-              "minLength": 1
-            },
-            "description": "Query parameters to include in requests to the host.",
-            "markdownDescription": "Query parameters to include in requests to the host.\n\nReference: https://docs.hypermode.com/define-hosts"
-          }
+      "additionalProperties": false,
+      "properties": {
+        "$schema": {
+          "type": "string",
+          "format": "uri",
+          "description": "The schema that the document should conform to.",
+          "markdownDescription": "The schema that the document should conform to.\n\nReference: https://json-schema.org/"
         },
-        "$comment": "Either baseUrl or endpoint must be provided, but not both.",
-        "allOf": [
-          {
-            "oneOf": [
-              {
-                "required": ["baseUrl"]
-              },
-              {
-                "required": ["endpoint"]
-              }
+        "hosts": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "name",
+              "endpoint"
             ],
-            "not": {
-              "required": ["baseUrl", "endpoint"]
+            "additionalProperties": false,
+            "properties": {
+              "name": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 63,
+                "pattern": "^(?!-|.*-$|.*--)[a-zA-Z0-9-]+$",
+                "description": "Internal name of your host. Used for indicating the host of a model or for a connection.",
+                "markdownDescription": "Internal name of your host. Used for indicating the host of a model or for a connection.\n\nReference: https://docs.hypermode.com/define-hosts"
+              },
+              "endpoint": {
+                "type": "string",
+                "format": "uri",
+                "minLength": 1,
+                "description": "URL and base path for connections to the host.",
+                "markdownDescription": "URL and base path for connections to the host.\n\nReference: https://docs.hypermode.com/define-hosts"
+              },
+              "authHeader": {
+                "type": "string",
+                "minLength": 1,
+                "description": "Authorization header name for connections to the host.",
+                "markdownDescription": "Authorization header name for connections to the host.\n\nReference: https://docs.hypermode.com/define-hosts"
+              }
             }
           }
-        ],
-        "additionalProperties": false
+        },
+        "models": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "name",
+              "task",
+              "sourceModel",
+              "provider",
+              "host"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "host": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 63,
+                "pattern": "^(?!-|.*-$|.*--)[a-zA-Z0-9-]+$",
+                "description": "Runtime provider of model. Can be dynamically deployed models on Hypermode or a project-defined host.",
+                "markdownDescription": "Runtime provider of model. Can be dynamically deployed models on Hypermode or a project-defined host.\n\nReference: https://docs.hypermode.com/define-models"
+              },
+              "name": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 63,
+                "pattern": "^(?!-|.*-$|.*--)[a-zA-Z0-9-]+$",
+                "description": "Internal name of your AI model. Used for indicating the model to use in an API call.",
+                "markdownDescription": "Internal name of your AI model. Used for indicating the model to use in an API call.\n\nReference: https://docs.hypermode.com/define-models"
+              },
+              "provider": {
+                "type": "string",
+                "minLength": 1,
+                "description": "Source location of model, such as 'hugging-face' or 'openai'.",
+                "markdownDescription": "Source location of model, such as 'hugging-face' or 'openai'.\n\nReference: https://docs.hypermode.com/define-models"
+              },
+              "sourceModel": {
+                "type": "string",
+                "minLength": 1,
+                "description": "Relative path of model within provider.",
+                "markdownDescription": "Relative path of model within provider.\n\nReference: https://docs.hypermode.com/define-models"
+              },
+              "task": {
+                "type": "string",
+                "minLength": 1,
+                "description": "Training intent of model, such as 'classification' or 'embedding'.",
+                "markdownDescription": "Training intent of model, such as 'classification' or 'embedding'.\n\nReference: https://docs.hypermode.com/define-models"
+              }
+            }
+          }
+        }
       }
     }
-  }
+  ]
 }


### PR DESCRIPTION
Use `"oneOf"` to allow either the new or the old format of the manifest.

We can undo this after all projects are aligned to the new format.