### PR TITLE
Add v1 compatibility to the reader

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "files.associations": {
+    "**/test/*.json": "jsonc"
+  }
+}

--- a/compat/v1/manifest.go
+++ b/compat/v1/manifest.go
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2024 Hypermode, Inc.
+ */
+
+package manifest
+
+type HypermodeManifest struct {
+	Models []ModelInfo `json:"models"`
+	Hosts  []HostInfo  `json:"hosts"`
+}
+
+type ModelTask string
+
+const (
+	ClassificationTask ModelTask = "classification"
+	EmbeddingTask      ModelTask = "embedding"
+	GenerationTask     ModelTask = "generation"
+)
+
+type ModelInfo struct {
+	Name        string    `json:"name"`
+	Task        ModelTask `json:"task"`
+	SourceModel string    `json:"sourceModel"`
+	Provider    string    `json:"provider"`
+	Host        string    `json:"host"`
+}
+
+type HostInfo struct {
+	Name       string `json:"name"`
+	Endpoint   string `json:"endpoint"`
+	AuthHeader string `json:"authHeader"`
+}

--- a/test/manifest_test.go
+++ b/test/manifest_test.go
@@ -11,9 +11,13 @@ import (
 //go:embed valid_hypermode.json
 var validManifest []byte
 
+//go:embed old_v1_hypermode.json
+var oldV1Manifest []byte
+
 func TestReadManifest(t *testing.T) {
 	// This should match the content of valid_hypermode.json
 	expectedManifest := manifest.HypermodeManifest{
+		Version: 2,
 		Models: map[string]manifest.ModelInfo{
 			"model-1": {
 				Name:        "model-1",
@@ -72,6 +76,65 @@ func TestReadManifest(t *testing.T) {
 	actualManifest, err := manifest.ReadManifest(validManifest)
 	if err != nil {
 		t.Errorf("Error reading manifest: %v", err)
+		return
+	}
+
+	if !reflect.DeepEqual(actualManifest, expectedManifest) {
+		t.Errorf("Expected manifest: %+v, but got: %+v", expectedManifest, actualManifest)
+	}
+}
+
+func TestReadV1Manifest(t *testing.T) {
+	// This should match the content of old_v1_hypermode.json, after translating it to the new structure
+	expectedManifest := manifest.HypermodeManifest{
+		Version: 1,
+		Models: map[string]manifest.ModelInfo{
+			"model-1": {
+				Name:        "model-1",
+				Task:        manifest.ClassificationTask,
+				SourceModel: "source-model-1",
+				Provider:    "provider-1",
+				Host:        "my-model-host",
+			},
+			"model-2": {
+				Name:        "model-2",
+				Task:        manifest.EmbeddingTask,
+				SourceModel: "source-model-2",
+				Provider:    "provider-2",
+				Host:        "hypermode",
+			},
+			"model-3": {
+				Name:        "model-3",
+				Task:        manifest.GenerationTask,
+				SourceModel: "source-model-3",
+				Provider:    "provider-3",
+				Host:        "hypermode",
+			},
+		},
+		Hosts: map[string]manifest.HostInfo{
+			"my-model-host": {
+				Name:     "my-model-host",
+				Endpoint: "https://models.example.com/full/path/to/model-1",
+				BaseURL:  "https://models.example.com/full/path/to/model-1",
+				Headers: map[string]string{
+					"X-API-Key": "{{" + manifest.V1AuthHeaderVariableName + "}}",
+				},
+			},
+			"my-graphql-api": {
+				Name:     "my-graphql-api",
+				Endpoint: "https://api.example.com/graphql",
+				BaseURL:  "https://api.example.com/graphql",
+				Headers: map[string]string{
+					"Authorization": "{{" + manifest.V1AuthHeaderVariableName + "}}",
+				},
+			},
+		},
+	}
+
+	actualManifest, err := manifest.ReadManifest(oldV1Manifest)
+	if err != nil {
+		t.Errorf("Error reading manifest: %v", err)
+		return
 	}
 
 	if !reflect.DeepEqual(actualManifest, expectedManifest) {

--- a/test/old_v1_hypermode.json
+++ b/test/old_v1_hypermode.json
@@ -1,0 +1,39 @@
+{
+  // Test old v1 Hypermode manifest file
+  "$schema": "https://manifest.hypermode.com/hypermode.json",
+  "models": [
+    {
+      "name": "model-1",
+      "task": "classification",
+      "sourceModel": "source-model-1",
+      "provider": "provider-1",
+      "host": "my-model-host"
+    },
+    {
+      "name": "model-2",
+      "task": "embedding",
+      "sourceModel": "source-model-2",
+      "provider": "provider-2",
+      "host": "hypermode"
+    },
+    {
+      "name": "model-3",
+      "task": "generation",
+      "sourceModel": "source-model-3",
+      "provider": "provider-3",
+      "host": "hypermode"
+    }
+  ],
+  "hosts": [
+    {
+      "name": "my-model-host",
+      "endpoint": "https://models.example.com/full/path/to/model-1",
+      "authHeader": "X-API-Key"
+    },
+    {
+      "name": "my-graphql-api",
+      "endpoint":"https://api.example.com/graphql",
+      "authHeader": "Authorization"
+    }
+  ]
+}

--- a/test/valid_hypermode.json
+++ b/test/valid_hypermode.json
@@ -1,6 +1,6 @@
 {
   // Test valid Hypermode manifest file
-  "$schema": "file:///Users/matt/Code/gohypermode/manifest/hypermode.json",
+  "$schema": "https://manifest.hypermode.com/hypermode.json",
   "models": {
     "model-1": {
       "task": "classification",


### PR DESCRIPTION
With this PR, the Go module can read manifests in either the old or the new format.  It also adds an integer version number to the code, with the old format version being `1` and the current format version being `2`, and an `IsCurrentVersion` function that can be used to provide a warning to the user if they're on an old version.

Note, from the user's perspective, we still want to keep the manifest "versionless" (there is no version number in the manifest itself).  Incrementing this version number should be a rare occurrence, and only done if we are making hard breaking changes to the manifest format.  Simply adding a new field or deprecating an old one should not be cause to increment the version.