### PR TITLE
Remove extraneous colon in basic auth

### DIFF
--- a/manifest.go
+++ b/manifest.go
@@ -242,7 +242,7 @@ func (h *HostInfo) GetVariables() []string {
 	return results
 }
 
-var templateRegex = regexp.MustCompile(`{{\s*(?:base64:\((.+?):(.+?)\)|(.+?))\s*}}`)
+var templateRegex = regexp.MustCompile(`{{\s*(?:base64\((.+?):(.+?)\)|(.+?))\s*}}`)
 
 func extractVariables(s string) []string {
 	matches := templateRegex.FindAllStringSubmatch(s, -1)

--- a/test/manifest_test.go
+++ b/test/manifest_test.go
@@ -67,7 +67,7 @@ func TestReadManifest(t *testing.T) {
 				Name:    "another-rest-api",
 				BaseURL: "https://api.example.com/v2/",
 				Headers: map[string]string{
-					"Authorization": "Basic {{base64:(USERNAME:PASSWORD)}}",
+					"Authorization": "Basic {{base64(USERNAME:PASSWORD)}}",
 				},
 			},
 		},

--- a/test/valid_hypermode.json
+++ b/test/valid_hypermode.json
@@ -43,7 +43,7 @@
     "another-rest-api": {
       "baseUrl": "https://api.example.com/v2/",
       "headers": {
-        "Authorization": "Basic {{base64:(USERNAME:PASSWORD)}}"
+        "Authorization": "Basic {{base64(USERNAME:PASSWORD)}}"
       }
     }
   }


### PR DESCRIPTION
Basic auth should be:

```json
      "headers": {
        "Authorization": "Basic {{base64(USERNAME:PASSWORD)}}"
      }
```

not

```json
      "headers": {
        "Authorization": "Basic {{base64:(USERNAME:PASSWORD)}}"
      }
```